### PR TITLE
Using a short name for 'orient' is deprecated.

### DIFF
--- a/soda/solar_data.py
+++ b/soda/solar_data.py
@@ -66,7 +66,7 @@ class SolarSite(object):
         df=df.set_index(idx)
 
         self.resource_data = df
-        self.meta_resource_data = meta.T.to_dict('r')[0]
+        self.meta_resource_data = meta.T.to_dict('records')[0]
         
         return df
     


### PR DESCRIPTION
Only the options: ('dict', list, 'series', 'split', 'records', 'index') will be used in a future version. Use one of the above to silence this warning.

Closes #2.